### PR TITLE
write database design for readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Things you may want to cover:
 |group_id|integer|null: false, foreign_key: true|
 
 ### Association
-- belongs_to :users
+- belongs_to :user
 - belongs_to :groups
 
 ## groupsテーブル

--- a/README.md
+++ b/README.md
@@ -22,3 +22,52 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+
+## usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|text|null: false, unique: true, index: true|
+
+### Association
+- has_many :messages
+- has_many :groups_users
+- has_many :groups, througth: :groups_users
+
+## messagesテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|text|text||
+|image|text||
+|time|timestamp||
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :users
+- belongs_to :groups
+
+## groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false|
+
+### Association
+
+- has_many :messages, dependent: :delete_all
+- has_many :groups_users
+- has_many :users, througth: :groups_users
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user


### PR DESCRIPTION
 #what
readme.mdにデータベース設計を記述。作成したテーブルは、users table, messages table, groups table and users_groups tableの4種類。

#why
chat-spaceに必要な機能を洗い出し、その機能に必要なデータベース設計をすることで、今後の作業の効率化を測るため。また、データベース設計をすることで、テーブル間の関係のイメージできるため。